### PR TITLE
allow passing versioned args

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,24 +10,29 @@ on:
 
 env:
   CTEST_OUTPUT_ON_FAILURE: 1
+  CPM_SOURCE_CACHE: ${{ github.workspace }}/cpm_modules
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-    
-    steps:
-    - uses: actions/checkout@v2
-    
-    - name: test and install local build
-      run: |
-        cmake -S test -B build/local
-        cmake --build build/local 
-        ./build/local/test
-        sudo cmake --build build/local --target install
 
-    - name: test installed build
-      run: |
-        cmake -S test -B build/installed -D TEST_INSTALLED_VERSION=1
-        cmake --build build/installed 
-        ./build/installed/test
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/cache@v2
+        with:
+          path: "**/cpm_modules"
+          key: ${{ github.workflow }}-cpm-modules-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
+
+      - name: test and install local build
+        run: |
+          cmake -S test -B build/local
+          cmake --build build/local 
+          ./build/local/test
+          sudo cmake --build build/local --target install
+
+      - name: test installed build
+        run: |
+          cmake -S test -B build/installed -D TEST_INSTALLED_VERSION=1
+          cmake --build build/installed 
+          ./build/installed/test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,18 +19,12 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     
-    - name: test local build
+    - name: test and install local build
       run: |
         cmake -S test -B build/local
         cmake --build build/local 
         ./build/local/test
-
-    - name: install dependencies
-      run: |
-        cmake -S test/dependency -B build/dependency
-        sudo cmake --build build/dependency --target install
-        cmake -S test/namespaced_dependency -B build/namespaced_dependency
-        sudo cmake --build build/namespaced_dependency --target install
+        sudo cmake --build build/local --target install
 
     - name: test installed build
       run: |

--- a/Config.cmake.in
+++ b/Config.cmake.in
@@ -2,11 +2,11 @@
 
 include(CMakeFindDependencyMacro)
 
-foreach(dependency "@PROJECT_DEPENDENCIES@")
+string(REGEX MATCHALL "[^;]+" SEPARATE_DEPENDENCIES "@PROJECT_DEPENDENCIES@")
+
+foreach(dependency ${SEPARATE_DEPENDENCIES})
   string(REPLACE " " ";" args "${dependency}")
-  if (NOT args STREQUAL "")
-    find_dependency(${args})
-  endif()
+  find_dependency(${args})
 endforeach()
 
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")

--- a/Config.cmake.in
+++ b/Config.cmake.in
@@ -2,8 +2,11 @@
 
 include(CMakeFindDependencyMacro)
 
-foreach(dependency @PROJECT_DEPENDENCIES@)
-  find_dependency(${dependency})
+foreach(dependency "@PROJECT_DEPENDENCIES@")
+  string(REPLACE " " ";" args "${dependency}")
+  if (NOT args STREQUAL "")
+    find_dependency(${args})
+  endif()
 endforeach()
 
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ See [here](https://github.com/TheLartians/ModernCppStarter/blob/master/CMakeList
 CPMAddPackage(
   NAME PackageProject.cmake
   GITHUB_REPOSITORY TheLartians/PackageProject.cmake
-  VERSION 1.4
+  VERSION 1.4.1
 )
 
 packageProject(
@@ -31,7 +31,7 @@ packageProject(
   # should match the target's INSTALL_INTERFACE include directory
   INCLUDE_DESTINATION include/${PROJECT_NAME}-${PROJECT_VERSION}
   # semicolon separated list of the project's dependencies
-  DEPENDENCIES ""
+  DEPENDENCIES "fmt 7.1.3;cxxopts 2.2.0"
   # (optional) create a header containing the version info
   # note that the path should be lowercase 
   VERSION_HEADER "${PROJECT_NAME}/version.h"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,6 +18,7 @@ else()
 endif()
 
 add_executable(test main.cpp)
+
 target_link_libraries(test 
   dependency 
   ns::namespaced_dependency 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,10 +10,17 @@ project(PackageProjectTest
 if (TEST_INSTALLED_VERSION)
   find_package(dependency 1.2.3 REQUIRED)
   find_package(namespaced_dependency 4.5.6 REQUIRED)
+  find_package(transitive_dependency 7.8.9 REQUIRED)
 else()
   add_subdirectory(dependency)
   add_subdirectory(namespaced_dependency)
+  add_subdirectory(transitive_dependency)
 endif()
 
 add_executable(test main.cpp)
-target_link_libraries(test dependency ns::namespaced_dependency)
+target_link_libraries(test 
+  dependency 
+  ns::namespaced_dependency 
+  transitive_dependency::transitive_dependency
+)
+

--- a/test/dependency/include/dependency/dependency.h
+++ b/test/dependency/include/dependency/dependency.h
@@ -1,5 +1,3 @@
 #pragma once
 
-#include <iostream>
-
 void dependencyFunction();

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -2,10 +2,17 @@
 #include <dependency/version.h>
 #include <namespaced_dependency/namespaced_dependency.h>
 #include <namespaced_dependency/version.h>
+#include <transitive_dependency/transitive_dependency.h>
+#include <transitive_dependency/version.h>
 #include <string>
 
 int main() {
   dependencyFunction();
   ns::namespacedDependencyFunction();
-  return DEPENDENCY_VERSION == std::string("1.2.3") && NAMESPACED_DEPENDENCY_VERSION == std::string("4.5.6") ? 0 : 1;
+  transitiveDependencyFunction();
+  auto result = true;
+  result &= DEPENDENCY_VERSION == std::string("1.2.3");
+  result &= NAMESPACED_DEPENDENCY_VERSION == std::string("4.5.6");
+  result &= TRANSITIVE_DEPENDENCY_VERSION == std::string("7.8.9");
+  return result ? 0 : 1;
 }

--- a/test/namespaced_dependency/include/namespaced_dependency/namespaced_dependency.h
+++ b/test/namespaced_dependency/include/namespaced_dependency/namespaced_dependency.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <iostream>
-
 namespace ns {
 
 	void namespacedDependencyFunction();

--- a/test/transitive_dependency/CMakeLists.txt
+++ b/test/transitive_dependency/CMakeLists.txt
@@ -1,0 +1,38 @@
+cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+
+project(transitive_dependency
+  VERSION 7.8.9
+  LANGUAGES CXX
+)
+
+include(cmake/CPM.cmake)
+
+CPMAddPackage(
+  NAME fmt
+  GIT_TAG 7.1.3
+  GITHUB_REPOSITORY fmtlib/fmt
+  OPTIONS "FMT_INSTALL YES"
+)
+
+add_library(${PROJECT_NAME} source/transitive_dependency.cpp)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
+target_link_libraries(${PROJECT_NAME} fmt)
+
+target_include_directories(transitive_dependency
+  PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include/${PROJECT_NAME}-${PROJECT_VERSION}>
+)
+
+add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../.. ${CMAKE_CURRENT_BINARY_DIR}/PackageProject)
+
+packageProject(
+  NAME ${PROJECT_NAME}
+  VERSION ${PROJECT_VERSION}
+  NAMESPACE ${PROJECT_NAME}
+  BINARY_DIR ${PROJECT_BINARY_DIR}
+  INCLUDE_DIR ${PROJECT_SOURCE_DIR}/include
+  INCLUDE_DESTINATION include/${PROJECT_NAME}-${PROJECT_VERSION}
+  VERSION_HEADER "transitive_dependency/version.h"
+  DEPENDENCIES "fmt 7.1.3"
+)

--- a/test/transitive_dependency/CMakeLists.txt
+++ b/test/transitive_dependency/CMakeLists.txt
@@ -14,9 +14,16 @@ CPMAddPackage(
   OPTIONS "FMT_INSTALL YES"
 )
 
+CPMAddPackage(
+  NAME cxxopts
+  GITHUB_REPOSITORY jarro2783/cxxopts
+  VERSION 2.2.0
+  OPTIONS "CXXOPTS_BUILD_EXAMPLES Off" "CXXOPTS_BUILD_TESTS Off"
+)
+
 add_library(${PROJECT_NAME} source/transitive_dependency.cpp)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
-target_link_libraries(${PROJECT_NAME} fmt)
+target_link_libraries(${PROJECT_NAME} fmt cxxopts)
 
 target_include_directories(transitive_dependency
   PUBLIC
@@ -34,5 +41,5 @@ packageProject(
   INCLUDE_DIR ${PROJECT_SOURCE_DIR}/include
   INCLUDE_DESTINATION include/${PROJECT_NAME}-${PROJECT_VERSION}
   VERSION_HEADER "transitive_dependency/version.h"
-  DEPENDENCIES "fmt 7.1.3"
+  DEPENDENCIES "fmt 7.1.3;cxxopts 2.2.0"
 )

--- a/test/transitive_dependency/cmake/CPM.cmake
+++ b/test/transitive_dependency/cmake/CPM.cmake
@@ -1,0 +1,21 @@
+set(CPM_DOWNLOAD_VERSION 0.28.3)
+
+if(CPM_SOURCE_CACHE)
+  # Expand relative path. This is important if the provided path contains a tilde (~)
+  get_filename_component(CPM_SOURCE_CACHE ${CPM_SOURCE_CACHE} ABSOLUTE)
+  set(CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+elseif(DEFINED ENV{CPM_SOURCE_CACHE})
+  set(CPM_DOWNLOAD_LOCATION "$ENV{CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+else()
+  set(CPM_DOWNLOAD_LOCATION "${CMAKE_BINARY_DIR}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+endif()
+
+if(NOT (EXISTS ${CPM_DOWNLOAD_LOCATION}))
+  message(STATUS "Downloading CPM.cmake to ${CPM_DOWNLOAD_LOCATION}")
+  file(DOWNLOAD
+       https://github.com/TheLartians/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
+       ${CPM_DOWNLOAD_LOCATION}
+  )
+endif()
+
+include(${CPM_DOWNLOAD_LOCATION})

--- a/test/transitive_dependency/include/transitive_dependency/transitive_dependency.h
+++ b/test/transitive_dependency/include/transitive_dependency/transitive_dependency.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <iostream>
+
+void transitiveDependencyFunction();

--- a/test/transitive_dependency/include/transitive_dependency/transitive_dependency.h
+++ b/test/transitive_dependency/include/transitive_dependency/transitive_dependency.h
@@ -1,5 +1,5 @@
 #pragma once
 
-#include <iostream>
+#include <fmt/format.h>
 
 void transitiveDependencyFunction();

--- a/test/transitive_dependency/source/transitive_dependency.cpp
+++ b/test/transitive_dependency/source/transitive_dependency.cpp
@@ -1,0 +1,6 @@
+#include <fmt/format.h>
+#include <transitive_dependency/version.h>
+
+void transitiveDependencyFunction() {
+  fmt::print("Using transitive_dependency version {}\n", TRANSITIVE_DEPENDENCY_VERSION);
+}


### PR DESCRIPTION
As it turns out, CMake's string / parameter handling is a bit more volatile than I thought

Fixes #12 