### PR TITLE
Fix potentially invalid macro name in generated version header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ function(packageProject)
       endif()
 
       string(TOUPPER ${PROJECT_NAME} UPPERCASE_PROJECT_NAME)
+      # ensure that the generated macro does not include invalid characters
       string(REGEX REPLACE [^a-zA-Z0-9] _ UPPERCASE_PROJECT_NAME ${UPPERCASE_PROJECT_NAME})
       configure_file(
         ${PACKAGE_PROJECT_ROOT_PATH}/version.h.in

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ function(packageProject)
       endif()
 
       string(TOUPPER ${PROJECT_NAME} UPPERCASE_PROJECT_NAME)
+      string(REGEX REPLACE [^a-zA-Z0-9] _ UPPERCASE_PROJECT_NAME ${UPPERCASE_PROJECT_NAME})
       configure_file(
         ${PACKAGE_PROJECT_ROOT_PATH}/version.h.in
         ${PROJECT_VERSION_INCLUDE_DIR}/${PROJECT_VERSION_HEADER} @ONLY


### PR DESCRIPTION
The generated name could be invalid if the target name contains characters that are not legal macro identifiers. This commit changes replaces all illegal characters with the underscore "_".

This should fix #37.